### PR TITLE
fix #1 - tags not loading when dataLayerName is not specified in the config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ class GoogleTagManagerPlugin {
       id: '',
       events: '',
       dataLayer: '',
-      dataLayerName: '',
+      dataLayerName: 'dataLayer',
       auth: '',
       preview: ''
     }


### PR DESCRIPTION
The lack of  'dataLayerName' value made the Google Tag Manager snippet to add empty &l= parameter into the URL, causing the GTM fail to load.